### PR TITLE
Fix #3 Full blocks in the method literals make index building wrong

### DIFF
--- a/src/Aleph-Tests/AlpIndexTestCase.class.st
+++ b/src/Aleph-Tests/AlpIndexTestCase.class.st
@@ -25,6 +25,12 @@ AlpIndexTestCase >> compiledMethod1Modified [
 	^ AlpMockModified >> #method1
 ]
 
+{ #category : #templates }
+AlpIndexTestCase >> compiledMethod2WithBlock [
+
+	^ AlpMockOriginal >> #method2WithBlock
+]
+
 { #category : #accessing }
 AlpIndexTestCase >> index [
 

--- a/src/Aleph-Tests/AlpMockOriginal.class.st
+++ b/src/Aleph-Tests/AlpMockOriginal.class.st
@@ -13,3 +13,13 @@ AlpMockOriginal >> method1 [
 		(1 + 1) printString, 
 		Object name
 ]
+
+{ #category : #templates }
+AlpMockOriginal >> method2WithBlock [
+	<aPragma>
+	<otherPragma: 42>
+	[ Class printString ] value.
+	^ self className, 
+		(1 + 1) printString, 
+		Object name
+]

--- a/src/Aleph-Tests/AlpReferencesIndexTest.class.st
+++ b/src/Aleph-Tests/AlpReferencesIndexTest.class.st
@@ -21,6 +21,14 @@ AlpReferencesIndexTest >> testIndexMethod [
 ]
 
 { #category : #tests }
+AlpReferencesIndexTest >> testIndexMethodWithBlock [
+
+	self index methodAdded: self compiledMethod2WithBlock.
+
+	self assert: (self index referencesTo: #Class) size equals: 1
+]
+
+{ #category : #tests }
 AlpReferencesIndexTest >> testMethodAdded [
 	"Self as indexMethod"
 

--- a/src/Aleph-Tests/AlpSendersIndexTest.class.st
+++ b/src/Aleph-Tests/AlpSendersIndexTest.class.st
@@ -27,6 +27,15 @@ AlpSendersIndexTest >> testIndexMethod [
 ]
 
 { #category : #tests }
+AlpSendersIndexTest >> testIndexMethodWithBlock [
+	
+	self index methodAdded: self compiledMethod2WithBlock.
+	
+	self assert: (self index referencesTo: #printString) size equals: 1.
+
+]
+
+{ #category : #tests }
 AlpSendersIndexTest >> testMethodAdded [
 	"Same as index method"
 

--- a/src/Aleph/AlpBasicIndex.class.st
+++ b/src/Aleph/AlpBasicIndex.class.st
@@ -63,18 +63,18 @@ AlpBasicIndex >> endRebuild [
 	table associationsDo: [ :assoc | assoc value: (assoc value asArray) ]
 ]
 
-{ #category : #accessing }
-AlpBasicIndex >> initialTableSize [
-
-	^ self subclassResponsibility 
-]
-
 { #category : #initialization }
 AlpBasicIndex >> initialize [
 
 	super initialize.
 	table := IdentityDictionary new: 10000.
 	duringRebuild := false.
+]
+
+{ #category : #accessing }
+AlpBasicIndex >> initialTableSize [
+
+	^ self subclassResponsibility 
 ]
 
 { #category : #accessing }

--- a/src/Aleph/AlpReferencesIndex.class.st
+++ b/src/Aleph/AlpReferencesIndex.class.st
@@ -31,7 +31,7 @@ AlpReferencesIndex >> methodRemoved: aMethod [
 { #category : #private }
 AlpReferencesIndex >> referencesOf: aMethod do: aBlock [
 
-	(aMethod literals 
+	(aMethod literalsEvenTheOnesInTheInnerBlocks 
 		select: [ :each | each isVariableBinding ]) asSet
 		do: [ :each | aBlock value: each key ]
 ]

--- a/src/Aleph/AlpSendersIndex.class.st
+++ b/src/Aleph/AlpSendersIndex.class.st
@@ -37,7 +37,7 @@ AlpSendersIndex >> sendersOf: aMethod do: aBlock [
 	| senders |
 	senders := Set new.
 
-	aMethod literals do: [ :each | each isSymbol ifTrue: [ senders add: each ] ].
+	aMethod literalsEvenTheOnesInTheInnerBlocks do: [ :each | each isSymbol ifTrue: [ senders add: each ] ].
 	aMethod specialLiterals do: [ :each | senders add: each].
 	aMethod pragmas do: [ :each | senders add: each selector ].
 	

--- a/src/Aleph/AlpTrieIndex.class.st
+++ b/src/Aleph/AlpTrieIndex.class.st
@@ -97,18 +97,18 @@ AlpTrieIndex >> endRebuild [
 	initialSubstringTable := nil.
 ]
 
-{ #category : #updating }
-AlpTrieIndex >> initialTableSize [
-
-	^ self subclassResponsibility
-]
-
 { #category : #initialization }
 AlpTrieIndex >> initialize [
 
 	super initialize.
 	beginsWithTrie := CTOptimizedTrie new.
 	substringTrie := CTOptimizedTrie new
+]
+
+{ #category : #updating }
+AlpTrieIndex >> initialTableSize [
+
+	^ self subclassResponsibility
 ]
 
 { #category : #testing }

--- a/src/Aleph/CompiledCode.extension.st
+++ b/src/Aleph/CompiledCode.extension.st
@@ -1,0 +1,18 @@
+Extension { #name : #CompiledCode }
+
+{ #category : #'*Aleph' }
+CompiledCode >> literalsEvenTheOnesInTheInnerBlocks [
+	"Imported from 129625bdce8e3f751985d605d43fc4b16ed43847
+	https://github.com/pharo-project/pharo/pull/8206"
+	| literals numberLiterals |
+	literals := OrderedCollection new:
+		            (numberLiterals := self numLiterals
+		                               - self literalsToSkip).
+	1 to: numberLiterals do: [ :index | 
+		| lit |
+		lit := self literalAt: index.
+		lit isEmbeddedBlock
+			ifTrue: [ literals addAll: lit literalsEvenTheOnesInTheInnerBlocks ]
+			ifFalse: [ literals addLast: lit ] ].
+	^ literals asArray
+]


### PR DESCRIPTION
 It uses the fix in https://github.com/pharo-project/pharo/pull/8206 . 
Maybe it should be changed to literals if the current behavior is wrong.