### PR TITLE
Speed improvement on implementors text completion 

### DIFF
--- a/src/Aleph/AlpBasicIndex.class.st
+++ b/src/Aleph/AlpBasicIndex.class.st
@@ -63,18 +63,18 @@ AlpBasicIndex >> endRebuild [
 	table associationsDo: [ :assoc | assoc value: (assoc value asArray) ]
 ]
 
-{ #category : #accessing }
-AlpBasicIndex >> initialTableSize [
-
-	^ self subclassResponsibility 
-]
-
 { #category : #initialization }
 AlpBasicIndex >> initialize [
 
 	super initialize.
 	table := IdentityDictionary new: 10000.
 	duringRebuild := false.
+]
+
+{ #category : #accessing }
+AlpBasicIndex >> initialTableSize [
+
+	^ self subclassResponsibility 
 ]
 
 { #category : #accessing }

--- a/src/Aleph/AlpIndexManager.class.st
+++ b/src/Aleph/AlpIndexManager.class.st
@@ -175,8 +175,8 @@ AlpIndexManager >> findReferencesTo: aLiteral [
 
 { #category : #query }
 AlpIndexManager >> findSelectorsStartingWith: aPrefix do: aBlock [
-
-	^(self indexAt: #implementors) withAllValuesBeginningWith: aPrefix do: aBlock
+	^(self indexAt: #implementors) withAllSelectorsBeginningWith: aPrefix
+		do: aBlock
 ]
 
 { #category : #query }

--- a/src/Aleph/AlpSystemNavigation.class.st
+++ b/src/Aleph/AlpSystemNavigation.class.st
@@ -34,9 +34,7 @@ AlpSystemNavigation >> allReferencesTo: aLiteral [
 
 { #category : #query }
 AlpSystemNavigation >> allSelectorsStartingWith: aString do: aBlock [
-
-	^ self manager findSelectorsStartingWith: aString do: [ :aMethod |
-		 aBlock value: aMethod selector]
+	^self manager findSelectorsStartingWith: aString do: aBlock
 ]
 
 { #category : #query }

--- a/src/Aleph/AlpTableBasedIndex.class.st
+++ b/src/Aleph/AlpTableBasedIndex.class.st
@@ -50,12 +50,6 @@ AlpTableBasedIndex >> entries [
 	^ entries
 ]
 
-{ #category : #updating }
-AlpTableBasedIndex >> initialTableSize [ 
-
-	self subclassResponsibility 
-]
-
 { #category : #'instance creation' }
 AlpTableBasedIndex >> initialize [
 	
@@ -63,6 +57,12 @@ AlpTableBasedIndex >> initialize [
 	entries := SortedCollection new.
 	substringStrategy := AlpDummyTableBasedSubstringStrategy new
 
+]
+
+{ #category : #updating }
+AlpTableBasedIndex >> initialTableSize [ 
+
+	self subclassResponsibility 
 ]
 
 { #category : #querying }
@@ -118,6 +118,20 @@ AlpTableBasedIndex >> resolveName: aString do: aBlock [
 AlpTableBasedIndex >> shutdown [
 	
 	entries := nil.
+]
+
+{ #category : #query }
+AlpTableBasedIndex >> withAllSelectorsBeginningWith: aString do: aBlockClosure [
+	| first found |
+	first := entries binarySearchMinimalIndexOf: aString.
+	first isZero ifTrue: [^self].
+	first to: entries size
+		do: 
+			[:i |
+			found := entries at: i.
+			(found beginsWith: aString)
+				ifTrue: [aBlockClosure value: found]
+				ifFalse: [^self]]
 ]
 
 { #category : #querying }

--- a/src/Aleph/AlpTrieIndex.class.st
+++ b/src/Aleph/AlpTrieIndex.class.st
@@ -97,18 +97,18 @@ AlpTrieIndex >> endRebuild [
 	initialSubstringTable := nil.
 ]
 
-{ #category : #updating }
-AlpTrieIndex >> initialTableSize [
-
-	^ self subclassResponsibility
-]
-
 { #category : #initialization }
 AlpTrieIndex >> initialize [
 
 	super initialize.
 	beginsWithTrie := CTOptimizedTrie new.
 	substringTrie := CTOptimizedTrie new
+]
+
+{ #category : #updating }
+AlpTrieIndex >> initialTableSize [
+
+	^ self subclassResponsibility
 ]
 
 { #category : #testing }


### PR DESCRIPTION
Hello there

I improved a little bit the logic to look for selectors starting with something (for the text completion)
When looking for common selectors like "on", the block adding entries to the text completion was evaluated 52201949 times (all implementors of all selectors starting with "on"), it took 25 seconds, I changed the logic to evaluate the block only on all selectors starting with "on" (no need to iterate on implementors in the context of the text completion), it's much faster

Other ideas of improvements i got: (not needed, text completion is already fast enough now)
 - keep a list of entries without duplicates in an instvar
 - when the text completion follows a block, a class, self... possible entries could be limited to selectors understood by the receiver, but this change shouldn't be in Aleph but in HeuristicCompletion packages