### PR TITLE
Aim to improve the speed of creating the cache

### DIFF
--- a/src/Aleph/AlpBasicIndex.class.st
+++ b/src/Aleph/AlpBasicIndex.class.st
@@ -63,18 +63,18 @@ AlpBasicIndex >> endRebuild [
 	table associationsDo: [ :assoc | assoc value: (assoc value asArray) ]
 ]
 
+{ #category : #accessing }
+AlpBasicIndex >> initialTableSize [
+
+	^ self subclassResponsibility 
+]
+
 { #category : #initialization }
 AlpBasicIndex >> initialize [
 
 	super initialize.
 	table := IdentityDictionary new: 10000.
 	duringRebuild := false.
-]
-
-{ #category : #accessing }
-AlpBasicIndex >> initialTableSize [
-
-	^ self subclassResponsibility 
 ]
 
 { #category : #accessing }

--- a/src/Aleph/AlpEncodedSpecialLiteralMapProvider.class.st
+++ b/src/Aleph/AlpEncodedSpecialLiteralMapProvider.class.st
@@ -55,13 +55,13 @@ AlpEncodedSpecialLiteralMapProvider >> createMapFor: anEncoderClass [
 AlpEncodedSpecialLiteralMapProvider >> initialize [
 
 	super initialize.
-	maps := SmallDictionary new
+	maps := IdentityDictionary new
 ]
 
 { #category : #accessing }
 AlpEncodedSpecialLiteralMapProvider >> mapAt: anEncoderClass [
 
 	^ maps 
-		at: anEncoderClass 
+		at: anEncoderClass name
 		ifAbsentPut: [ self createMapFor: anEncoderClass ]
 ]

--- a/src/Aleph/AlpImplementorsIndexWithTable.class.st
+++ b/src/Aleph/AlpImplementorsIndexWithTable.class.st
@@ -40,7 +40,7 @@ AlpImplementorsIndexWithTable >> beginRebuild [
 
 	super beginRebuild.
 
-	selectorsMap := Dictionary new: (self statistics at: #numberOfSymbols) 
+	selectorsMap := IdentityDictionary new: (self statistics at: #numberOfSymbols) 
 ]
 
 { #category : #accessing }
@@ -64,7 +64,7 @@ AlpImplementorsIndexWithTable >> endRebuild [
 AlpImplementorsIndexWithTable >> initialize [
 	
 	super initialize.
-	selectorsMap := Dictionary new
+	selectorsMap := IdentityDictionary new
 	
 ]
 

--- a/src/Aleph/AlpImplementorsIndexWithTable.class.st
+++ b/src/Aleph/AlpImplementorsIndexWithTable.class.st
@@ -43,6 +43,23 @@ AlpImplementorsIndexWithTable >> beginRebuild [
 	selectorsMap := Dictionary new: (self statistics at: #numberOfSymbols) 
 ]
 
+{ #category : #accessing }
+AlpImplementorsIndexWithTable >> defaultEntitiesForRebuild [
+	^ OrderedCollection new: self initialTableSize
+]
+
+{ #category : #updating }
+AlpImplementorsIndexWithTable >> endRebuild [
+	| temporaryEntries |
+	super endRebuild.
+	
+	temporaryEntries := SortedCollection new: self initialTableSize.
+	entries do: [ :each | temporaryEntries addLast: each ].
+	temporaryEntries reSort.
+	
+	entries := temporaryEntries
+]
+
 { #category : #initialization }
 AlpImplementorsIndexWithTable >> initialize [
 	

--- a/src/Aleph/AlpSendersIndex.class.st
+++ b/src/Aleph/AlpSendersIndex.class.st
@@ -33,9 +33,11 @@ AlpSendersIndex >> methodRemoved: aMethod [
 { #category : #private }
 AlpSendersIndex >> sendersOf: aMethod do: aBlock [
 
-	"I use a Set to guarantee that the repeted literals are only stored once"
+	"I use a set to guarantee that the repeted literals are only stored once.
+	
+	I use an IdentitySet instead of a Set to gain speed, as we can compare symbols by identity. "
 	| senders |
-	senders := Set new.
+	senders := IdentitySet new.
 
 	aMethod literalsEvenTheOnesInTheInnerBlocks do: [ :each | each isSymbol ifTrue: [ senders add: each ] ].
 	aMethod specialLiterals do: [ :each | senders add: each].

--- a/src/Aleph/AlpTableBasedIndex.class.st
+++ b/src/Aleph/AlpTableBasedIndex.class.st
@@ -50,6 +50,12 @@ AlpTableBasedIndex >> entries [
 	^ entries
 ]
 
+{ #category : #updating }
+AlpTableBasedIndex >> initialTableSize [ 
+
+	self subclassResponsibility 
+]
+
 { #category : #'instance creation' }
 AlpTableBasedIndex >> initialize [
 	
@@ -57,12 +63,6 @@ AlpTableBasedIndex >> initialize [
 	entries := SortedCollection new.
 	substringStrategy := AlpDummyTableBasedSubstringStrategy new
 
-]
-
-{ #category : #updating }
-AlpTableBasedIndex >> initialTableSize [ 
-
-	self subclassResponsibility 
 ]
 
 { #category : #querying }

--- a/src/Aleph/AlpTableBasedIndex.class.st
+++ b/src/Aleph/AlpTableBasedIndex.class.st
@@ -35,7 +35,7 @@ AlpTableBasedIndex >> beginRebuild [
 
 	super beginRebuild.
 
-	entries := SortedCollection new: self initialTableSize.
+	entries := self defaultEntitiesForRebuild.
 	substringStrategy beginRebuildFor: self
 ]
 
@@ -43,6 +43,11 @@ AlpTableBasedIndex >> beginRebuild [
 AlpTableBasedIndex >> clear [
 
 	self initialize
+]
+
+{ #category : #accessing }
+AlpTableBasedIndex >> defaultEntitiesForRebuild [
+	^ SortedCollection new: self initialTableSize
 ]
 
 { #category : #accessing }

--- a/src/Aleph/AlpTrieIndex.class.st
+++ b/src/Aleph/AlpTrieIndex.class.st
@@ -97,18 +97,18 @@ AlpTrieIndex >> endRebuild [
 	initialSubstringTable := nil.
 ]
 
+{ #category : #updating }
+AlpTrieIndex >> initialTableSize [
+
+	^ self subclassResponsibility
+]
+
 { #category : #initialization }
 AlpTrieIndex >> initialize [
 
 	super initialize.
 	beginsWithTrie := CTOptimizedTrie new.
 	substringTrie := CTOptimizedTrie new
-]
-
-{ #category : #updating }
-AlpTrieIndex >> initialTableSize [
-
-	^ self subclassResponsibility
 ]
 
 { #category : #testing }

--- a/src/Aleph/CompiledMethod.extension.st
+++ b/src/Aleph/CompiledMethod.extension.st
@@ -5,7 +5,7 @@ CompiledMethod >> specialLiterals [
 	| results specialLiteralMap |
 
 	specialLiteralMap := self encoderClass encodedSpecialLiteralMap.
-	results := Set new.
+	results := IdentitySet new.
 	(InstructionStream on: self) scanFor: [ :instr | 
 		specialLiteralMap 
 			at: instr 


### PR DESCRIPTION
This aims to improve the time the cache is created by:
- Use an `IdentityDictionary` instead of a `Dictionary` to store implementors per selectors in `AlpImplementorsIndexWithTable`
- Use an `IdentitySet` instead of a `Set` to store sender selectors in `AlpSendersIndex`
- Sort selectors after the index was created in `AlpImplementorsIndexWithTable >> endRebuild`

Not 100% sure if this does not have other side-effects, but the switch `IdentityDictionary` and `IdentitySet` when working with symbols seems ok.