### PR TITLE
Remove Symbol class>>#numberOfSymbols

### DIFF
--- a/src/Aleph/AlpIndexManager.class.st
+++ b/src/Aleph/AlpIndexManager.class.st
@@ -189,8 +189,11 @@ AlpIndexManager >> findSendersOf: aLiteral [
 AlpIndexManager >> generateStatistics [
 
 	^ statistics := Dictionary newFromPairs: { 
-		#numberOfClasses. SystemNavigation default environment classNames size.
-	 	#numberOfSymbols. Symbol numberOfSymbols } 
+			                #numberOfClasses.
+			                SystemNavigation default environment classNames
+				                size.
+			                #numberOfSymbols.
+			                Symbol allSymbols size }
 ]
 
 { #category : #private }

--- a/src/Aleph/Symbol.extension.st
+++ b/src/Aleph/Symbol.extension.st
@@ -1,8 +1,0 @@
-Extension { #name : #Symbol }
-
-{ #category : #'*Aleph' }
-Symbol class >> numberOfSymbols [
-
-	^ NewSymbols size + OneCharacterSymbols size + SymbolTable size.
-
-]


### PR DESCRIPTION
Caused an exception on Pharo 11 because in Pharo 11 OneCharacterSymbols doesn't exist anymore